### PR TITLE
Issue #18502 - update for D10 compatibility

### DIFF
--- a/lynx.info.yml
+++ b/lynx.info.yml
@@ -1,8 +1,7 @@
 name: 'OS Search Lynx'
 description: 'Os feature to search across os installs'
 type: module
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - "drupal:vsite"
   - "drupal:elasticsearch_connector"

--- a/src/EventSubscriber/LynxRequestSubscriber.php
+++ b/src/EventSubscriber/LynxRequestSubscriber.php
@@ -3,8 +3,8 @@
 namespace Drupal\lynx\EventSubscriber;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -35,10 +35,10 @@ class LynxRequestSubscriber implements EventSubscriberInterface {
   /**
    * Performs an internal redirect to lynx search page.
    *
-   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
    *   The Event to process.
    */
-  public function onKernelRequestLynx(GetResponseEvent $event) {
+  public function onKernelRequestLynx(RequestEvent $event) {
     $request = $event->getRequest();
     $host = $request->getHttpHost();
     $uri = $request->getPathInfo();


### PR DESCRIPTION
## Issue
https://github.com/openscholar/openscholar/issues/18502

## Description
- Update core version requirements
- Replace deprecated parameter 
```
web/modules/contrib/lynx/src/EventSubscriber/LynxRequestSubscriber.php | 41 | Parameter $event of method Drupal\lynx\EventSubscriber\LynxRequestSubscriber::onKernelRequestLynx() has typehint with deprecated class Symfony\Component\HttpKernel\Event\GetResponseEvent: since Symfony 4.3, use RequestEvent instead
```

## Notes
These were the only two issues automatically flagged by Upgrade Status report. I'm not sure how to test this locally. I'm getting errors like the following, but I'm not sure if it's because there's a true problem or because the elasticsearch index for lynx isn't fully set up in local environments. The changes are small, and hardly anyone uses LYNX, so maybe we should just merge them into the main repo and test after deployment?

```
Warning: Undefined array key "elasticsearch_index_db_os_search_index" in Drupal\lynx\Controller\SearchPage->render() (line 176 of modules/contrib/lynx/src/Controller/SearchPage.php).

Warning: Trying to access array offset on value of type null in Drupal\lynx\Controller\SearchPage->render() (line 176 of modules/contrib/lynx/src/Controller/SearchPage.php).

The website encountered an unexpected error. Please try again later.

InvalidArgumentException: The URI '/group/7' is invalid. You must use a valid URI scheme. in Drupal\Core\Url::fromUri() (line 293 of core/lib/Drupal/Core/Url.php).
Drupal\lynx\Controller\SearchPage->createRenderArray(Array) (Line: 208)
Drupal\lynx\Controller\SearchPage->render('test')
call_user_func_array(Array, Array) (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 580)
Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 124)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array) (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 169)
Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 81)
Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 58)
Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 48)
Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 106)
Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 85)
Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 48)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 51)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 718)
Drupal\Core\DrupalKernel->handle(Object) (Line: 19)
```